### PR TITLE
add pytest-cov and codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,28 @@
-sudo: true
-dist: trusty
+language: python
+python:
+  - "3.6"
 
 notifications:
   email: false
 
-services:
-  - docker
-
 install:
-  - cd docker; ./build.sh
-  - docker images
+  - ./setup_travis_env.sh
+
+before_script:
+  - source path.bash.inc
 
 matrix:
   include:
     - env: lint check
-      script: docker run arraiy/torchgeometry /bin/bash -c "source path.bash.inc && python verify.py --check lint"
-
+      script: python verify.py --check lint
+    
     - env: static check
-      script: docker run arraiy/torchgeometry /bin/bash -c "source path.bash.inc && python verify.py --check mypy"
-
+      script: python verify.py --check mypy
+    
     - env: docs
-      script: docker run arraiy/torchgeometry /bin/bash -c "source path.bash.inc && python verify.py --check build-docs"
-
-    - env: test
-      script: docker run arraiy/torchgeometry /bin/bash -c "source path.bash.inc && pytest --cov=torchgeometry test/"
-
-after_success:
-  - bash < (curl -s https://codecov.io/bash)
+      script: python verify.py --check build-docs
+    
+    - env: unit tests
+      script: pytest --cov=torchgeometry test
+      after_success:
+        - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
This Pull Request does the following:
  - Move travis ci back to matrix expansion
    - using docker was a bad idea since slows down the whole things compared to matrices.
  - Adds pytest-cov and codecov reports
    - run the unit tests with coverage and sends the report online to codecov