### PR TITLE
Feat/depth warper single pinhole

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,3 +2,4 @@ sphinx
 sphinx_rtd_theme
 nbsphinx
 numpy
+tornado<6

--- a/torchgeometry/core/depth_warper.py
+++ b/torchgeometry/core/depth_warper.py
@@ -1,4 +1,4 @@
-from typing import Optional, Iterable, Union
+from typing import Optional, Union
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -27,8 +27,8 @@ class DepthWarper(nn.Module):
         I_{src} = \\omega(I_{dst}, P_{src}^{\{dst\}}, D_{src})
 
     Args:
-        pinholes_dst (Iterable[PinholeCamera]): the pinhole models for the
-          destination frame.
+        pinholes_dst (PinholeCamera): the pinhole models for the destination
+          frame.
         height (int): the height of the image to warp.
         width (int): the width of the image to warp.
         mode (Optional[str]): interpolation mode to calculate output values
@@ -38,7 +38,7 @@ class DepthWarper(nn.Module):
     """
 
     def __init__(self,
-                 pinholes_dst: Iterable[PinholeCamera],
+                 pinhole_dst: PinholeCamera,
                  height: int, width: int,
                  mode: Optional[str] = 'bilinear',
                  padding_mode: Optional[str] = 'zeros'):
@@ -51,7 +51,7 @@ class DepthWarper(nn.Module):
         self.eps = 1e-6
 
         # state members
-        self._pinhole_dst: PinholeCamerasList = PinholeCamerasList(pinholes_dst)
+        self._pinhole_dst: PinholeCamera = pinhole_dst
         self._pinhole_src: Union[None, PinholeCamera] = None
         self._dst_proj_src: Union[None, torch.Tensor] = None
 
@@ -67,39 +67,32 @@ class DepthWarper(nn.Module):
             self, pinhole_src: PinholeCamera) -> 'DepthWarper':
         r"""Computes the projection matrix from the source to destinaion frame.
         """
+        if not isinstance(self._pinhole_dst, PinholeCamera):
+            raise TypeError("Member self._pinhole_dst expected to be of class "
+                            "PinholeCamera. Got {}"
+                            .format(type(self._pinhole_dst)))
         if not isinstance(pinhole_src, PinholeCamera):
             raise TypeError("Argument pinhole_src expected to be of class "
                             "PinholeCamera. Got {}".format(type(pinhole_src)))
         # compute the relative pose between the non reference and the reference
         # camera frames.
-        batch_size: int = pinhole_src.batch_size
-        num_cameras: int = self._pinhole_dst.num_cameras
-
-        extrinsics_src: torch.Tensor = pinhole_src.extrinsics[:, None].expand(
-            -1, num_cameras, -1, -1)  # BxNx4x4
-        extrinsics_src = extrinsics_src.contiguous().view(-1, 4, 4)  # (B*N)x4x4
-        extrinsics_dst: torch.Tensor = self._pinhole_dst.extrinsics.view(
-            -1, 4, 4)  # (B*N)x4x4
         dst_trans_src: torch.Tensor = relative_transformation(
-            extrinsics_src, extrinsics_dst)
+            pinhole_src.extrinsics, self._pinhole_dst.extrinsics)
 
         # compute the projection matrix between the non reference cameras and
         # the reference.
-        intrinsics_dst: torch.Tensor = self._pinhole_dst.intrinsics.view(
-            -1, 4, 4)
         dst_proj_src: torch.Tensor = torch.matmul(
-            intrinsics_dst, dst_trans_src)
+            self._pinhole_dst.intrinsics, dst_trans_src)
 
         # update class members
         self._pinhole_src = pinhole_src
-        self._dst_proj_src = dst_proj_src.view(
-            pinhole_src.batch_size, -1, 4, 4)
+        self._dst_proj_src = dst_proj_src
         return self
 
     def _compute_projection(self, x, y, invd):
         point = torch.FloatTensor([[[x], [y], [1.0], [invd]]])
         flow = torch.matmul(
-            self._dst_proj_src[:, 0], point.to(self._dst_proj_src.device))
+            self._dst_proj_src, point.to(self._dst_proj_src.device))
         z = 1. / flow[:, 2]
         x = (flow[:, 0] * z)
         y = (flow[:, 1] * z)
@@ -155,16 +148,9 @@ class DepthWarper(nn.Module):
             self._pinhole_src.intrinsics_inverse().to(dtype),
             pixel_coords)  # BxHxWx3
 
-        # create views from tensors to match with cam2pixel expected shapes
-        cam_coords_src = cam_coords_src[:, None].expand(
-            -1, self._pinhole_dst.num_cameras, -1, -1, -1)  # BxNxHxWx3
-        cam_coords_src = cam_coords_src.contiguous().view(
-            -1, height, width, 3)                          # (B*N)xHxWx3
-        dst_proj_src: torch.Tensor = self._dst_proj_src.view(-1, 4, 4)
-
         # reproject the camera coordinates to the pixel
         pixel_coords_src: torch.Tensor = cam2pixel(
-            cam_coords_src, dst_proj_src.to(dtype))  # (B*N)xHxWx2
+            cam_coords_src, self._dst_proj_src.to(dtype))  # (B*N)xHxWx2
 
         # normalize between -1 and 1 the coordinates
         pixel_coords_src_norm: torch.Tensor = normalize_pixel_coordinates(
@@ -195,12 +181,12 @@ class DepthWarper(nn.Module):
             >>> pinhole_dst = tgm.PinholeCamera(...)
             >>> pinhole_src = tgm.PinholeCamera(...)
             >>> # create the depth warper, compute the projection matrix
-            >>> warper = tgm.DepthWarper([pinhole_dst, ], height, width)
+            >>> warper = tgm.DepthWarper(pinhole_dst, height, width)
             >>> warper.compute_projection_matrix(pinhole_src)
             >>> # warp the destionation frame to reference by depth
             >>> depth_src = torch.ones(1, 1, 32, 32)  # Nx1xHxW
             >>> image_dst = torch.rand(1, 3, 32, 32)  # NxCxHxW
-            >>> image_src = warper(depth_src, image_dst)    # NxCxHxW
+            >>> image_src = warper(depth_src, image_dst)  # NxCxHxW
         """
         return F.grid_sample(patch_dst, self.warp_grid(depth_src),
                              mode=self.mode, padding_mode=self.padding_mode)
@@ -208,7 +194,7 @@ class DepthWarper(nn.Module):
 
 # functional api
 
-def depth_warp(pinholes_dst: Iterable[PinholeCamera],
+def depth_warp(pinhole_dst: PinholeCamera,
                pinhole_src: PinholeCamera,
                depth_src: torch.Tensor,
                patch_dst: torch.Tensor,
@@ -225,9 +211,9 @@ def depth_warp(pinholes_dst: Iterable[PinholeCamera],
         >>> # warp the destionation frame to reference by depth
         >>> depth_src = torch.ones(1, 1, 32, 32)  # Nx1xHxW
         >>> image_dst = torch.rand(1, 3, 32, 32)  # NxCxHxW
-        >>> image_src = tgm.depth_warp([pinhole_dst, ], pinhole_src,
+        >>> image_src = tgm.depth_warp(pinhole_dst, pinhole_src,
         >>>     depth_src, image_dst, height, width)  # NxCxHxW
     """
-    warper = DepthWarper(pinholes_dst, height, width)
+    warper = DepthWarper(pinhole_dst, height, width)
     warper.compute_projection_matrix(pinhole_src)
     return warper(depth_src, patch_dst)


### PR DESCRIPTION
This PR simplifies the `DepthWarper` API.

Before:
```python
warper = DepthWarper([pinhole1, pinhole2,], height, width)
```

Now:
```python
warper = DepthWarper(pinhole1 height, width)
```