### PR TITLE
create metrics module and implement confusion_matrix and mean_iou

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -23,6 +23,7 @@ TGM focuses on Image and tensor warping functions such as:
    core
    image
    losses
+   metrics
    contrib
    utils
 

--- a/docs/source/metrics.rst
+++ b/docs/source/metrics.rst
@@ -4,3 +4,4 @@ torchgeometry.metrics
 .. currentmodule:: torchgeometry.metrics
 
 .. autofunction:: confusion_matrix
+.. autofunction:: mean_iou

--- a/docs/source/metrics.rst
+++ b/docs/source/metrics.rst
@@ -1,0 +1,6 @@
+torchgeometry.metrics
+=====================
+
+.. currentmodule:: torchgeometry.metrics
+
+.. autofunction:: confusion_matrix

--- a/mypy_files.txt
+++ b/mypy_files.txt
@@ -9,3 +9,5 @@ torchgeometry/losses/tversky.py
 torchgeometry/losses/depth_smooth.py
 torchgeometry/contrib/spatial_soft_argmax2d.py
 torchgeometry/contrib/extract_patches.py
+torchgeometry/metrics/confusion_matrix.py
+torchgeometry/metrics/mean_iou.py

--- a/setup_travis_env.sh
+++ b/setup_travis_env.sh
@@ -19,7 +19,7 @@ fi
 
 # Install CPU-PyTorch
 $sdk_dir/.dev_env/bin/conda install -y \
-  pytorch-nightly \
+  pytorch-cpu==1.0.1 \
   -c pytorch
 
 # Tests dependencies

--- a/test/test_contrib.py
+++ b/test/test_contrib.py
@@ -8,12 +8,12 @@ import utils
 
 
 class TestExtractTensorPatches:
-    def _test_smoke(self):
+    def test_smoke(self):
         input = torch.arange(16.).view(1, 1, 4, 4)
         m = tgm.contrib.ExtractTensorPatches(3)
         assert m(input).shape == (1, 4, 1, 3, 3)
 
-    def _test_b1_ch1_h4w4_ws3(self):
+    def test_b1_ch1_h4w4_ws3(self):
         input = torch.arange(16.).view(1, 1, 4, 4)
         m = tgm.contrib.ExtractTensorPatches(3)
         patches = m(input)
@@ -23,7 +23,7 @@ class TestExtractTensorPatches:
         assert utils.check_equal_torch(input[0, :, 1:, :3], patches[0, 2])
         assert utils.check_equal_torch(input[0, :, 1:, 1:], patches[0, 3])
 
-    def _test_b1_ch2_h4w4_ws3(self):
+    def test_b1_ch2_h4w4_ws3(self):
         input = torch.arange(16.).view(1, 1, 4, 4)
         input = input.expand(-1, 2, -1, -1)  # copy all channels
         m = tgm.contrib.ExtractTensorPatches(3)
@@ -34,7 +34,7 @@ class TestExtractTensorPatches:
         assert utils.check_equal_torch(input[0, :, 1:, :3], patches[0, 2])
         assert utils.check_equal_torch(input[0, :, 1:, 1:], patches[0, 3])
 
-    def _test_b1_ch1_h4w4_ws2(self):
+    def test_b1_ch1_h4w4_ws2(self):
         input = torch.arange(16.).view(1, 1, 4, 4)
         m = tgm.contrib.ExtractTensorPatches(2)
         patches = m(input)
@@ -44,7 +44,7 @@ class TestExtractTensorPatches:
         assert utils.check_equal_torch(input[0, :, 1:3, 1:3], patches[0, 4])
         assert utils.check_equal_torch(input[0, :, 2:4, 1:3], patches[0, 7])
 
-    def _test_b1_ch1_h4w4_ws2_stride2(self):
+    def test_b1_ch1_h4w4_ws2_stride2(self):
         input = torch.arange(16.).view(1, 1, 4, 4)
         m = tgm.contrib.ExtractTensorPatches(2, stride=2)
         patches = m(input)
@@ -54,7 +54,7 @@ class TestExtractTensorPatches:
         assert utils.check_equal_torch(input[0, :, 2:4, 0:2], patches[0, 2])
         assert utils.check_equal_torch(input[0, :, 2:4, 2:4], patches[0, 3])
 
-    def _test_b1_ch1_h4w4_ws2_stride21(self):
+    def test_b1_ch1_h4w4_ws2_stride21(self):
         input = torch.arange(16.).view(1, 1, 4, 4)
         m = tgm.contrib.ExtractTensorPatches(2, stride=(2, 1))
         patches = m(input)
@@ -64,7 +64,7 @@ class TestExtractTensorPatches:
         assert utils.check_equal_torch(input[0, :, 2:4, 0:2], patches[0, 3])
         assert utils.check_equal_torch(input[0, :, 2:4, 2:4], patches[0, 5])
 
-    def _test_b1_ch1_h3w3_ws2_stride1_padding1(self):
+    def test_b1_ch1_h3w3_ws2_stride1_padding1(self):
         input = torch.arange(9.).view(1, 1, 3, 3)
         m = tgm.contrib.ExtractTensorPatches(2, stride=1, padding=1)
         patches = m(input)
@@ -74,7 +74,7 @@ class TestExtractTensorPatches:
         assert utils.check_equal_torch(input[0, :, 1:3, 0:2], patches[0, 9])
         assert utils.check_equal_torch(input[0, :, 1:3, 1:3], patches[0, 10])
 
-    def _test_b2_ch1_h3w3_ws2_stride1_padding1(self):
+    def test_b2_ch1_h3w3_ws2_stride1_padding1(self):
         batch_size = 2
         input = torch.arange(9.).view(1, 1, 3, 3)
         input = input.expand(batch_size, -1, -1, -1)
@@ -91,7 +91,7 @@ class TestExtractTensorPatches:
             assert utils.check_equal_torch(
                 input[i, :, 1:3, 1:3], patches[i, 10])
 
-    def _test_b1_ch1_h3w3_ws23(self):
+    def test_b1_ch1_h3w3_ws23(self):
         input = torch.arange(9.).view(1, 1, 3, 3)
         m = tgm.contrib.ExtractTensorPatches((2, 3))
         patches = m(input)
@@ -99,7 +99,7 @@ class TestExtractTensorPatches:
         assert utils.check_equal_torch(input[0, :, 0:2, 0:3], patches[0, 0])
         assert utils.check_equal_torch(input[0, :, 1:3, 0:3], patches[0, 1])
 
-    def _test_b1_ch1_h3w4_ws23(self):
+    def test_b1_ch1_h3w4_ws23(self):
         input = torch.arange(12.).view(1, 1, 3, 4)
         m = tgm.contrib.ExtractTensorPatches((2, 3))
         patches = m(input)
@@ -110,27 +110,14 @@ class TestExtractTensorPatches:
         assert utils.check_equal_torch(input[0, :, 1:3, 1:4], patches[0, 3])
 
     # TODO: implement me
-    def _test_jit(self):
+    def test_jit(self):
         pass
 
-    def _test_gradcheck(self):
+    def test_gradcheck(self):
         input = torch.rand(2, 3, 4, 4)
         input = utils.tensor_to_gradcheck_var(input)  # to var
         assert gradcheck(tgm.contrib.extract_tensor_patches,
                          (input, 3,), raise_exception=True)
-
-    def test_run_all(self):
-        self._test_smoke()
-        self._test_b1_ch1_h4w4_ws3()
-        self._test_b1_ch2_h4w4_ws3()
-        self._test_b1_ch1_h4w4_ws2()
-        self._test_b1_ch1_h3w3_ws23()
-        self._test_b1_ch1_h3w4_ws23()
-        self._test_b1_ch1_h4w4_ws2_stride2()
-        self._test_b1_ch1_h4w4_ws2_stride21()
-        self._test_b1_ch1_h3w3_ws2_stride1_padding1()
-        self._test_b2_ch1_h3w3_ws2_stride1_padding1()
-        self._test_gradcheck()
 
 
 class TestSoftArgmax2d:

--- a/test/test_metrics.py
+++ b/test/test_metrics.py
@@ -16,7 +16,7 @@ class TestMeanIoU:
         predicted = torch.tensor(
             [[1, 1, 1, 1, 0, 0, 0, 0]])
 
-        mean_iou = tgm.metrics.mean_iou(actual, predicted, num_classes)
+        mean_iou = tgm.metrics.mean_iou(predicted, actual, num_classes)
         assert mean_iou.shape == (1, num_classes)
         assert pytest.approx(mean_iou[..., 0].item(), 1.00)
         assert pytest.approx(mean_iou[..., 1].item(), 1.00)
@@ -28,7 +28,7 @@ class TestMeanIoU:
         predicted = torch.tensor(
             [[1, 1, 1, 1, 0, 0, 0, 1]])
 
-        mean_iou = tgm.metrics.mean_iou(actual, predicted, num_classes)
+        mean_iou = tgm.metrics.mean_iou(predicted, actual, num_classes)
         assert mean_iou.shape == (1, num_classes)
         assert pytest.approx(mean_iou[..., 0].item(), 0.75)
         assert pytest.approx(mean_iou[..., 1].item(), 0.80)
@@ -46,7 +46,7 @@ class TestMeanIoU:
               [2, 2, 3, 3],
               [2, 2, 3, 3]]])
 
-        mean_iou = tgm.metrics.mean_iou(actual, predicted, num_classes)
+        mean_iou = tgm.metrics.mean_iou(predicted, actual, num_classes)
         assert mean_iou.shape == (1, num_classes)
         assert pytest.approx(mean_iou[..., 0].item(), 1.00)
         assert pytest.approx(mean_iou[..., 1].item(), 1.00)
@@ -66,7 +66,7 @@ class TestMeanIoU:
               [2, 2, 3, 3],
               [2, 2, 3, 3]]])
 
-        mean_iou = tgm.metrics.mean_iou(actual, predicted, num_classes)
+        mean_iou = tgm.metrics.mean_iou(predicted, actual, num_classes)
         assert mean_iou.shape == (1, num_classes)
         assert pytest.approx(mean_iou[..., 0].item(), 0.00)
         assert pytest.approx(mean_iou[..., 1].item(), 0.00)
@@ -82,7 +82,7 @@ class TestConfusionMatrix:
         predicted = torch.tensor(
             [[1, 1, 1, 1, 0, 0, 0, 1]])
 
-        conf_mat = tgm.metrics.confusion_matrix(actual, predicted, num_classes)
+        conf_mat = tgm.metrics.confusion_matrix(predicted, actual, num_classes)
         assert conf_mat[..., 0, 0].item() == 3
         assert conf_mat[..., 0, 1].item() == 1
         assert conf_mat[..., 1, 0].item() == 0
@@ -95,16 +95,12 @@ class TestConfusionMatrix:
         predicted = torch.tensor(
             [[2, 1, 0, 0, 0, 0, 0, 1, 0, 2, 2, 1, 0, 0, 2, 2]])
 
-        conf_mat = tgm.metrics.confusion_matrix(actual, predicted, num_classes)
-        assert conf_mat[..., 0, 0].item() == 4
-        assert conf_mat[..., 0, 1].item() == 1
-        assert conf_mat[..., 0, 2].item() == 2
-        assert conf_mat[..., 1, 0].item() == 3
-        assert conf_mat[..., 1, 1].item() == 0
-        assert conf_mat[..., 1, 2].item() == 2
-        assert conf_mat[..., 2, 0].item() == 1
-        assert conf_mat[..., 2, 1].item() == 2
-        assert conf_mat[..., 2, 2].item() == 1
+        conf_mat = tgm.metrics.confusion_matrix(predicted, actual, num_classes)
+        conf_mat_real = torch.tensor(
+            [[[4, 1, 2],
+              [3, 0, 2],
+              [1, 2, 1]]])
+        assert torch.equal(conf_mat, conf_mat_real)
 
     def test_four_classes_2d_perfect(self):
         num_classes = 4
@@ -119,7 +115,7 @@ class TestConfusionMatrix:
               [2, 2, 3, 3],
               [2, 2, 3, 3]]])
 
-        conf_mat = tgm.metrics.confusion_matrix(actual, predicted, num_classes)
+        conf_mat = tgm.metrics.confusion_matrix(predicted, actual, num_classes)
         conf_mat_real = torch.tensor(
             [[[4, 0, 0, 0],
               [0, 4, 0, 0],
@@ -140,7 +136,7 @@ class TestConfusionMatrix:
               [2, 2, 1, 3],
               [2, 2, 3, 3]]])
 
-        conf_mat = tgm.metrics.confusion_matrix(actual, predicted, num_classes)
+        conf_mat = tgm.metrics.confusion_matrix(predicted, actual, num_classes)
         conf_mat_real = torch.tensor(
             [[[3, 0, 0, 1],
               [1, 3, 0, 0],
@@ -161,7 +157,7 @@ class TestConfusionMatrix:
               [2, 2, 3, 3],
               [2, 2, 3, 3]]])
 
-        conf_mat = tgm.metrics.confusion_matrix(actual, predicted, num_classes)
+        conf_mat = tgm.metrics.confusion_matrix(predicted, actual, num_classes)
         conf_mat_real = torch.tensor(
             [[[0, 0, 0, 4],
               [0, 4, 0, 0],
@@ -182,7 +178,7 @@ class TestConfusionMatrix:
               [2, 2, 3, 3],
               [2, 2, 3, 3]]])
 
-        conf_mat = tgm.metrics.confusion_matrix(actual, predicted, num_classes)
+        conf_mat = tgm.metrics.confusion_matrix(predicted, actual, num_classes)
         conf_mat_real = torch.tensor(
             [[[0, 0, 4, 4],
               [0, 0, 0, 0],

--- a/test/test_metrics.py
+++ b/test/test_metrics.py
@@ -10,6 +10,7 @@ from common import device_type
 
 class TestMeanIoU:
     def test_two_classes_perfect(self):
+        batch_size = 1
         num_classes = 2
         actual = torch.tensor(
             [[1, 1, 1, 1, 0, 0, 0, 0]])
@@ -17,11 +18,27 @@ class TestMeanIoU:
             [[1, 1, 1, 1, 0, 0, 0, 0]])
 
         mean_iou = tgm.metrics.mean_iou(predicted, actual, num_classes)
-        assert mean_iou.shape == (1, num_classes)
-        assert pytest.approx(mean_iou[..., 0].item(), 1.00)
-        assert pytest.approx(mean_iou[..., 1].item(), 1.00)
+        mean_iou_real = torch.tensor(
+            [[1.0, 1.0]], dtype=torch.float32)
+        assert mean_iou.shape == (batch_size, num_classes)
+        assert utils.check_equal_torch(mean_iou, mean_iou_real)
+
+    def test_two_classes_perfect_batch2(self):
+        batch_size = 2
+        num_classes = 2
+        actual = torch.tensor(
+            [[1, 1, 1, 1, 0, 0, 0, 0]]).repeat(batch_size, 1)
+        predicted = torch.tensor(
+            [[1, 1, 1, 1, 0, 0, 0, 0]]).repeat(batch_size, 1)
+
+        mean_iou = tgm.metrics.mean_iou(predicted, actual, num_classes)
+        mean_iou_real = torch.tensor(
+            [[1.0, 1.0]], dtype=torch.float32)
+        assert mean_iou.shape == (batch_size, num_classes)
+        assert utils.check_equal_torch(mean_iou, mean_iou_real)
 
     def test_two_classes(self):
+        batch_size = 1
         num_classes = 2
         actual = torch.tensor(
             [[1, 1, 1, 1, 0, 0, 0, 0]])
@@ -29,11 +46,14 @@ class TestMeanIoU:
             [[1, 1, 1, 1, 0, 0, 0, 1]])
 
         mean_iou = tgm.metrics.mean_iou(predicted, actual, num_classes)
-        assert mean_iou.shape == (1, num_classes)
-        assert pytest.approx(mean_iou[..., 0].item(), 0.75)
-        assert pytest.approx(mean_iou[..., 1].item(), 0.80)
+        mean_iou = tgm.metrics.mean_iou(predicted, actual, num_classes)
+        mean_iou_real = torch.tensor(
+            [[0.75, 0.80]], dtype=torch.float32)
+        assert mean_iou.shape == (batch_size, num_classes)
+        assert utils.check_equal_torch(mean_iou, mean_iou_real)
 
     def test_four_classes_2d_perfect(self):
+        batch_size = 1
         num_classes = 4
         actual = torch.tensor(
             [[[0, 0, 1, 1],
@@ -47,13 +67,13 @@ class TestMeanIoU:
               [2, 2, 3, 3]]])
 
         mean_iou = tgm.metrics.mean_iou(predicted, actual, num_classes)
-        assert mean_iou.shape == (1, num_classes)
-        assert pytest.approx(mean_iou[..., 0].item(), 1.00)
-        assert pytest.approx(mean_iou[..., 1].item(), 1.00)
-        assert pytest.approx(mean_iou[..., 2].item(), 1.00)
-        assert pytest.approx(mean_iou[..., 3].item(), 1.00)
+        mean_iou_real = torch.tensor(
+            [[1.0, 1.0, 1.0, 1.0]], dtype=torch.float32)
+        assert mean_iou.shape == (batch_size, num_classes)
+        assert utils.check_equal_torch(mean_iou, mean_iou_real)
 
     def test_four_classes_2d_one_class_no_predicted(self):
+        batch_size = 1
         num_classes = 4
         actual = torch.tensor(
             [[[0, 0, 0, 0],
@@ -67,11 +87,10 @@ class TestMeanIoU:
               [2, 2, 3, 3]]])
 
         mean_iou = tgm.metrics.mean_iou(predicted, actual, num_classes)
-        assert mean_iou.shape == (1, num_classes)
-        assert pytest.approx(mean_iou[..., 0].item(), 0.00)
-        assert pytest.approx(mean_iou[..., 1].item(), 0.00)
-        assert pytest.approx(mean_iou[..., 2].item(), 0.50)
-        assert pytest.approx(mean_iou[..., 3].item(), 0.50)
+        mean_iou_real = torch.tensor(
+            [[0.0, 0.0, 0.5, 0.5]], dtype=torch.float32)
+        assert mean_iou.shape == (batch_size, num_classes)
+        assert utils.check_equal_torch(mean_iou, mean_iou_real)
 
 
 class TestConfusionMatrix:
@@ -81,6 +100,20 @@ class TestConfusionMatrix:
             [[1, 1, 1, 1, 0, 0, 0, 0]])
         predicted = torch.tensor(
             [[1, 1, 1, 1, 0, 0, 0, 1]])
+
+        conf_mat = tgm.metrics.confusion_matrix(predicted, actual, num_classes)
+        conf_mat_real = torch.tensor(
+            [[[3, 1],
+              [0, 4]]], dtype=torch.float32)
+        assert utils.check_equal_torch(conf_mat, conf_mat_real)
+
+    def test_two_classes_batch2(self):
+        batch_size = 2
+        num_classes = 2
+        actual = torch.tensor(
+            [[1, 1, 1, 1, 0, 0, 0, 0]]).repeat(batch_size, 1)
+        predicted = torch.tensor(
+            [[1, 1, 1, 1, 0, 0, 0, 1]]).repeat(batch_size, 1)
 
         conf_mat = tgm.metrics.confusion_matrix(predicted, actual, num_classes)
         conf_mat_real = torch.tensor(

--- a/test/test_metrics.py
+++ b/test/test_metrics.py
@@ -1,0 +1,125 @@
+import pytest
+
+import torch
+import torchgeometry as tgm
+from torch.autograd import gradcheck
+
+import utils
+from common import device_type
+
+
+class TestConfusionMatrix:
+    def test_two_classes(self):
+        num_classes = 2
+        actual = torch.tensor(
+            [[1, 1, 1, 1, 0, 0, 0, 0]])
+        predicted = torch.tensor(
+            [[1, 1, 1, 1, 0, 0, 0, 1]])
+
+        conf_mat = tgm.metrics.confusion_matrix(actual, predicted, num_classes)
+        assert conf_mat[..., 0, 0].item() == 3
+        assert conf_mat[..., 0, 1].item() == 1
+        assert conf_mat[..., 1, 0].item() == 0
+        assert conf_mat[..., 1, 1].item() == 4
+
+    def test_three_classes(self):
+        num_classes = 3
+        actual = torch.tensor(
+            [[2, 2, 0, 0, 1, 0, 0, 2, 1, 1, 0, 0, 1, 2, 1, 0]])
+        predicted = torch.tensor(
+            [[2, 1, 0, 0, 0, 0, 0, 1, 0, 2, 2, 1, 0, 0, 2, 2]])
+
+        conf_mat = tgm.metrics.confusion_matrix(actual, predicted, num_classes)
+        assert conf_mat[..., 0, 0].item() == 4
+        assert conf_mat[..., 0, 1].item() == 1
+        assert conf_mat[..., 0, 2].item() == 2
+        assert conf_mat[..., 1, 0].item() == 3
+        assert conf_mat[..., 1, 1].item() == 0
+        assert conf_mat[..., 1, 2].item() == 2
+        assert conf_mat[..., 2, 0].item() == 1
+        assert conf_mat[..., 2, 1].item() == 2
+        assert conf_mat[..., 2, 2].item() == 1
+
+    def test_four_classes_2d_perfect(self):
+        num_classes = 4
+        actual = torch.tensor(
+            [[[0, 0, 1, 1],
+              [0, 0, 1, 1],
+              [2, 2, 3, 3],
+              [2, 2, 3, 3]]])
+        predicted = torch.tensor(
+            [[[0, 0, 1, 1],
+              [0, 0, 1, 1],
+              [2, 2, 3, 3],
+              [2, 2, 3, 3]]])
+
+        conf_mat = tgm.metrics.confusion_matrix(actual, predicted, num_classes)
+        conf_mat_real = torch.tensor(
+            [[[4, 0, 0, 0],
+              [0, 4, 0, 0],
+              [0, 0, 4, 0],
+              [0, 0, 0, 4]]])
+        assert torch.equal(conf_mat, conf_mat_real)
+
+    def test_four_classes_2d_one_class_nonperfect(self):
+        num_classes = 4
+        actual = torch.tensor(
+            [[[0, 0, 1, 1],
+              [0, 0, 1, 1],
+              [2, 2, 3, 3],
+              [2, 2, 3, 3]]])
+        predicted = torch.tensor(
+            [[[0, 0, 1, 1],
+              [0, 3, 0, 1],
+              [2, 2, 1, 3],
+              [2, 2, 3, 3]]])
+
+        conf_mat = tgm.metrics.confusion_matrix(actual, predicted, num_classes)
+        conf_mat_real = torch.tensor(
+            [[[3, 0, 0, 1],
+              [1, 3, 0, 0],
+              [0, 0, 4, 0],
+              [0, 1, 0, 3]]])
+        assert torch.equal(conf_mat, conf_mat_real)
+
+    def test_four_classes_2d_one_class_missing(self):
+        num_classes = 4
+        actual = torch.tensor(
+            [[[0, 0, 1, 1],
+              [0, 0, 1, 1],
+              [2, 2, 3, 3],
+              [2, 2, 3, 3]]])
+        predicted = torch.tensor(
+            [[[3, 3, 1, 1],
+              [3, 3, 1, 1],
+              [2, 2, 3, 3],
+              [2, 2, 3, 3]]])
+
+        conf_mat = tgm.metrics.confusion_matrix(actual, predicted, num_classes)
+        conf_mat_real = torch.tensor(
+            [[[0, 0, 0, 4],
+              [0, 4, 0, 0],
+              [0, 0, 4, 0],
+              [0, 0, 0, 4]]])
+        assert torch.equal(conf_mat, conf_mat_real)
+
+    def test_four_classes_2d_one_class_no_predicted(self):
+        num_classes = 4
+        actual = torch.tensor(
+            [[[0, 0, 0, 0],
+              [0, 0, 0, 0],
+              [2, 2, 3, 3],
+              [2, 2, 3, 3]]])
+        predicted = torch.tensor(
+            [[[3, 3, 2, 2],
+              [3, 3, 2, 2],
+              [2, 2, 3, 3],
+              [2, 2, 3, 3]]])
+
+        conf_mat = tgm.metrics.confusion_matrix(actual, predicted, num_classes)
+        conf_mat_real = torch.tensor(
+            [[[0, 0, 4, 4],
+              [0, 0, 0, 0],
+              [0, 0, 4, 0],
+              [0, 0, 0, 4]]])
+        assert torch.equal(conf_mat, conf_mat_real)

--- a/test/test_metrics.py
+++ b/test/test_metrics.py
@@ -8,6 +8,72 @@ import utils
 from common import device_type
 
 
+class TestMeanIoU:
+    def test_two_classes_perfect(self):
+        num_classes = 2
+        actual = torch.tensor(
+            [[1, 1, 1, 1, 0, 0, 0, 0]])
+        predicted = torch.tensor(
+            [[1, 1, 1, 1, 0, 0, 0, 0]])
+
+        mean_iou = tgm.metrics.mean_iou(actual, predicted, num_classes)
+        assert mean_iou.shape == (1, num_classes)
+        assert pytest.approx(mean_iou[..., 0].item(), 1.00)
+        assert pytest.approx(mean_iou[..., 1].item(), 1.00)
+
+    def test_two_classes(self):
+        num_classes = 2
+        actual = torch.tensor(
+            [[1, 1, 1, 1, 0, 0, 0, 0]])
+        predicted = torch.tensor(
+            [[1, 1, 1, 1, 0, 0, 0, 1]])
+
+        mean_iou = tgm.metrics.mean_iou(actual, predicted, num_classes)
+        assert mean_iou.shape == (1, num_classes)
+        assert pytest.approx(mean_iou[..., 0].item(), 0.75)
+        assert pytest.approx(mean_iou[..., 1].item(), 0.80)
+
+    def test_four_classes_2d_perfect(self):
+        num_classes = 4
+        actual = torch.tensor(
+            [[[0, 0, 1, 1],
+              [0, 0, 1, 1],
+              [2, 2, 3, 3],
+              [2, 2, 3, 3]]])
+        predicted = torch.tensor(
+            [[[0, 0, 1, 1],
+              [0, 0, 1, 1],
+              [2, 2, 3, 3],
+              [2, 2, 3, 3]]])
+
+        mean_iou = tgm.metrics.mean_iou(actual, predicted, num_classes)
+        assert mean_iou.shape == (1, num_classes)
+        assert pytest.approx(mean_iou[..., 0].item(), 1.00)
+        assert pytest.approx(mean_iou[..., 1].item(), 1.00)
+        assert pytest.approx(mean_iou[..., 2].item(), 1.00)
+        assert pytest.approx(mean_iou[..., 3].item(), 1.00)
+
+    def test_four_classes_2d_one_class_no_predicted(self):
+        num_classes = 4
+        actual = torch.tensor(
+            [[[0, 0, 0, 0],
+              [0, 0, 0, 0],
+              [2, 2, 3, 3],
+              [2, 2, 3, 3]]])
+        predicted = torch.tensor(
+            [[[3, 3, 2, 2],
+              [3, 3, 2, 2],
+              [2, 2, 3, 3],
+              [2, 2, 3, 3]]])
+
+        mean_iou = tgm.metrics.mean_iou(actual, predicted, num_classes)
+        assert mean_iou.shape == (1, num_classes)
+        assert pytest.approx(mean_iou[..., 0].item(), 0.00)
+        assert pytest.approx(mean_iou[..., 1].item(), 0.00)
+        assert pytest.approx(mean_iou[..., 2].item(), 0.50)
+        assert pytest.approx(mean_iou[..., 3].item(), 0.50)
+
+
 class TestConfusionMatrix:
     def test_two_classes(self):
         num_classes = 2

--- a/test/test_metrics.py
+++ b/test/test_metrics.py
@@ -83,10 +83,10 @@ class TestConfusionMatrix:
             [[1, 1, 1, 1, 0, 0, 0, 1]])
 
         conf_mat = tgm.metrics.confusion_matrix(predicted, actual, num_classes)
-        assert conf_mat[..., 0, 0].item() == 3
-        assert conf_mat[..., 0, 1].item() == 1
-        assert conf_mat[..., 1, 0].item() == 0
-        assert conf_mat[..., 1, 1].item() == 4
+        conf_mat_real = torch.tensor(
+            [[[3, 1],
+              [0, 4]]], dtype=torch.float32)
+        assert utils.check_equal_torch(conf_mat, conf_mat_real)
 
     def test_three_classes(self):
         num_classes = 3
@@ -99,8 +99,25 @@ class TestConfusionMatrix:
         conf_mat_real = torch.tensor(
             [[[4, 1, 2],
               [3, 0, 2],
-              [1, 2, 1]]])
-        assert torch.equal(conf_mat, conf_mat_real)
+              [1, 2, 1]]], dtype=torch.float32)
+        assert utils.check_equal_torch(conf_mat, conf_mat_real)
+
+    def test_three_classes_normalized(self):
+        num_classes = 3
+        normalized = True
+        actual = torch.tensor(
+            [[2, 2, 0, 0, 1, 0, 0, 2, 1, 1, 0, 0, 1, 2, 1, 0]])
+        predicted = torch.tensor(
+            [[2, 1, 0, 0, 0, 0, 0, 1, 0, 2, 2, 1, 0, 0, 2, 2]])
+
+        conf_mat = tgm.metrics.confusion_matrix(
+            predicted, actual, num_classes, normalized)
+
+        conf_mat_real = torch.tensor(
+            [[[0.5000, 0.3333, 0.4000],
+              [0.3750, 0.0000, 0.4000],
+              [0.1250, 0.6667, 0.2000]]], dtype=torch.float32)
+        assert utils.check_equal_torch(conf_mat, conf_mat_real)
 
     def test_four_classes_2d_perfect(self):
         num_classes = 4
@@ -120,8 +137,8 @@ class TestConfusionMatrix:
             [[[4, 0, 0, 0],
               [0, 4, 0, 0],
               [0, 0, 4, 0],
-              [0, 0, 0, 4]]])
-        assert torch.equal(conf_mat, conf_mat_real)
+              [0, 0, 0, 4]]], dtype=torch.float32)
+        assert utils.check_equal_torch(conf_mat, conf_mat_real)
 
     def test_four_classes_2d_one_class_nonperfect(self):
         num_classes = 4
@@ -141,8 +158,8 @@ class TestConfusionMatrix:
             [[[3, 0, 0, 1],
               [1, 3, 0, 0],
               [0, 0, 4, 0],
-              [0, 1, 0, 3]]])
-        assert torch.equal(conf_mat, conf_mat_real)
+              [0, 1, 0, 3]]], dtype=torch.float32)
+        assert utils.check_equal_torch(conf_mat, conf_mat_real)
 
     def test_four_classes_2d_one_class_missing(self):
         num_classes = 4
@@ -162,8 +179,8 @@ class TestConfusionMatrix:
             [[[0, 0, 0, 4],
               [0, 4, 0, 0],
               [0, 0, 4, 0],
-              [0, 0, 0, 4]]])
-        assert torch.equal(conf_mat, conf_mat_real)
+              [0, 0, 0, 4]]], dtype=torch.float32)
+        assert utils.check_equal_torch(conf_mat, conf_mat_real)
 
     def test_four_classes_2d_one_class_no_predicted(self):
         num_classes = 4
@@ -183,5 +200,5 @@ class TestConfusionMatrix:
             [[[0, 0, 4, 4],
               [0, 0, 0, 0],
               [0, 0, 4, 0],
-              [0, 0, 0, 4]]])
-        assert torch.equal(conf_mat, conf_mat_real)
+              [0, 0, 0, 4]]], dtype=torch.float32)
+        assert utils.check_equal_torch(conf_mat, conf_mat_real)

--- a/torchgeometry/__init__.py
+++ b/torchgeometry/__init__.py
@@ -5,6 +5,7 @@ from torchgeometry import image
 from torchgeometry import losses
 from torchgeometry import contrib
 from torchgeometry import utils
+from torchgeometry import metrics
 
 # Exposes ``torchgeometry.core`` package to top level
 from .core.homography_warper import HomographyWarper, homography_warp

--- a/torchgeometry/metrics/__init__.py
+++ b/torchgeometry/metrics/__init__.py
@@ -1,0 +1,1 @@
+from .confusion_matrix import confusion_matrix

--- a/torchgeometry/metrics/__init__.py
+++ b/torchgeometry/metrics/__init__.py
@@ -1,1 +1,2 @@
 from .confusion_matrix import confusion_matrix
+from .mean_iou import mean_iou

--- a/torchgeometry/metrics/confusion_matrix.py
+++ b/torchgeometry/metrics/confusion_matrix.py
@@ -1,0 +1,47 @@
+from typing import Optional
+
+import torch
+
+
+def confusion_matrix(
+        y_true: torch.Tensor,
+        y_pred: torch.Tensor,
+        num_classes: int) -> torch.Tensor:
+    r"""Compute confusion matrix to evaluate the accuracy of a classification.
+
+    Args:
+        y_true (torch.Tensor) : tensor with ground truth (correct) target
+          values. The shape can be :math:`(N, *)`.
+        y_pred (torch.Tensor) : tensor with estimated targets returned by a
+          classifier. The shape can be :math:`(N, *)`.
+        num_classes (int): total number of classes in y_true.
+
+    Returns:
+        torch.Tensor: a tensor with the confusion matrix with shape
+        :math:`(N, C, C)` where C is the number of classes.
+    """
+    if not torch.is_tensor(y_true):
+        raise TypeError("Input y_true type is not a torch.Tensor. Got {}"
+                        .format(type(y_true)))
+    if not torch.is_tensor(y_pred):
+        raise TypeError("Input y_pred type is not a torch.Tensor. Got {}"
+                        .format(type(y_pred)))
+    if not y_true.shape == y_pred.shape:
+        raise ValueError("Inputs y_true and y_pred must have the same shape. "
+                         "Got: {}".format(y_true.shape, y_pred.shape))
+    if not y_true.device == y_pred.device:
+        raise ValueError("Inputs must be in the same device. "
+                         "Got: {} - {}".format(y_true.device, y_pred.device))
+    if not isinstance(num_classes, int) or num_classes < 2:
+        raise ValueError("The number of classes must be an intenger bigger "
+                         "than two. Got: {}".format(num_classes))
+    batch_size: int = y_true.shape[0]
+    y_true_vec: torch.Tensor = y_true.view(batch_size, -1)
+    y_pred_vec: torch.Tensor = y_pred.view(batch_size, -1)
+
+    # NOTE: torch.bincount does not implement batched version
+    pre_bincount: torch.Tensor = y_true_vec * num_classes + y_pred_vec
+    confusion_vec: torch.Tensor = torch.stack([
+        torch.bincount(pb) for pb in pre_bincount
+    ])
+    return confusion_vec.view(batch_size, num_classes, num_classes)  # BxNxN

--- a/torchgeometry/metrics/mean_iou.py
+++ b/torchgeometry/metrics/mean_iou.py
@@ -1,0 +1,55 @@
+import torch
+
+from torchgeometry.metrics import confusion_matrix
+
+
+def mean_iou(
+        labels: torch.Tensor,
+        predictions: torch.Tensor,
+        num_classes: int) -> torch.Tensor:
+    r"""Calculate mean Intersection-Over-Union (mIOU).
+
+    Args:
+        labels (torch.Tensor) : tensor with ground truth (correct) target
+          values. The shape can be :math:`(N, *)`.
+        predictions (torch.Tensor) : tensor with estimated targets returned by
+          a classifier. The shape can be :math:`(N, *)`.
+        num_classes (int): total possible number of classes in labels.
+
+    Returns:
+        torch.Tensor: a tensor representing the mean intersection-over union.
+    """
+    if not torch.is_tensor(labels):
+        raise TypeError("Input labels type is not a torch.Tensor. Got {}"
+                        .format(type(labels)))
+    if not torch.is_tensor(predictions):
+        raise TypeError("Input predictions type is not a torch.Tensor. Got {}"
+                        .format(type(predictions)))
+    if not labels.shape == predictions.shape:
+        raise ValueError("Inputs labels and predictions must have the same "
+                         "shape. Got: {}".format(labels.shape,
+                                                 predictions.shape))
+    if not labels.device == predictions.device:
+        raise ValueError("Inputs must be in the same device. "
+                         "Got: {} - {}".format(labels.device,
+                                               predictions.device))
+    if not isinstance(num_classes, int) or num_classes < 2:
+        raise ValueError("The number of classes must be an intenger bigger "
+                         "than two. Got: {}".format(num_classes))
+    # we first compute the confusion matrix
+    conf_mat: torch.Tensor = confusion_matrix(labels, predictions, num_classes)
+
+    # allocate output tensor
+    batch_size: int = conf_mat.shape[0]
+    ious: torch.Tensor = torch.zeros(
+        batch_size, num_classes, device=conf_mat.device)
+
+    # TODO: is it possible to vectorize this ?
+    # iterate over classes
+    for class_id in range(num_classes):
+        tp: torch.Tensor = conf_mat[..., class_id, class_id].float()
+        total = torch.sum(conf_mat[..., class_id, :], dim=-1, keepdim=True) + \
+            torch.sum(conf_mat[..., :, class_id], dim=-1, keepdim=True)
+        iou_val: torch.Tensor = tp / (total.float() - tp + 1e-6)
+        ious[..., class_id:class_id + 1] += iou_val
+    return ious

--- a/torchgeometry/metrics/mean_iou.py
+++ b/torchgeometry/metrics/mean_iou.py
@@ -4,40 +4,47 @@ from torchgeometry.metrics import confusion_matrix
 
 
 def mean_iou(
-        labels: torch.Tensor,
-        predictions: torch.Tensor,
+        input: torch.Tensor,
+        target: torch.Tensor,
         num_classes: int) -> torch.Tensor:
     r"""Calculate mean Intersection-Over-Union (mIOU).
 
+    The function internally computes the confusion matrix.
+
     Args:
-        labels (torch.Tensor) : tensor with ground truth (correct) target
-          values. The shape can be :math:`(N, *)`.
-        predictions (torch.Tensor) : tensor with estimated targets returned by
-          a classifier. The shape can be :math:`(N, *)`.
-        num_classes (int): total possible number of classes in labels.
+        input (torch.Tensor) : tensor with estimated targets returned by a
+          classifier. The shape can be :math:`(B, *)` and must contain integer
+          values between 0 and K-1.
+        target (torch.Tensor) : tensor with ground truth (correct) target
+          values. The shape can be :math:`(B, *)` and must contain integer
+          values between 0 and K-1, whete targets are assumed to be provided as
+          one-hot vectors.
+        num_classes (int): total possible number of classes in target.
+        labels: torch.Tensor,
+        predictions: torch.Tensor,
+        num_classes: int) -> torch.Tensor:
 
     Returns:
-        torch.Tensor: a tensor representing the mean intersection-over union.
+        torch.Tensor: a tensor representing the mean intersection-over union
+        with shape :math:`(B, C)` where C is the number of classes.
     """
-    if not torch.is_tensor(labels):
-        raise TypeError("Input labels type is not a torch.Tensor. Got {}"
-                        .format(type(labels)))
-    if not torch.is_tensor(predictions):
-        raise TypeError("Input predictions type is not a torch.Tensor. Got {}"
-                        .format(type(predictions)))
-    if not labels.shape == predictions.shape:
-        raise ValueError("Inputs labels and predictions must have the same "
-                         "shape. Got: {}".format(labels.shape,
-                                                 predictions.shape))
-    if not labels.device == predictions.device:
+    if not isinstance(input, torch.LongTensor):
+        raise TypeError("Input input type is not a torch.LongTensor. Got {}"
+                        .format(type(input)))
+    if not isinstance(target, torch.LongTensor):
+        raise TypeError("Input target type is not a torch.LongTensor. Got {}"
+                        .format(type(target)))
+    if not input.shape == target.shape:
+        raise ValueError("Inputs input and target must have the same shape. "
+                         "Got: {}".format(input.shape, target.shape))
+    if not input.device == target.device:
         raise ValueError("Inputs must be in the same device. "
-                         "Got: {} - {}".format(labels.device,
-                                               predictions.device))
+                         "Got: {} - {}".format(input.device, target.device))
     if not isinstance(num_classes, int) or num_classes < 2:
         raise ValueError("The number of classes must be an intenger bigger "
                          "than two. Got: {}".format(num_classes))
     # we first compute the confusion matrix
-    conf_mat: torch.Tensor = confusion_matrix(labels, predictions, num_classes)
+    conf_mat: torch.Tensor = confusion_matrix(input, target, num_classes)
 
     # allocate output tensor
     batch_size: int = conf_mat.shape[0]

--- a/torchgeometry/metrics/mean_iou.py
+++ b/torchgeometry/metrics/mean_iou.py
@@ -54,7 +54,7 @@ def mean_iou(
     # TODO: is it possible to vectorize this ?
     # iterate over classes
     for class_id in range(num_classes):
-        tp: torch.Tensor = conf_mat[..., class_id, class_id].float()
+        tp: torch.Tensor = conf_mat[..., None, class_id, class_id]
         total = torch.sum(conf_mat[..., class_id, :], dim=-1, keepdim=True) + \
             torch.sum(conf_mat[..., :, class_id], dim=-1, keepdim=True)
         iou_val: torch.Tensor = tp / (total.float() - tp + 1e-6)


### PR DESCRIPTION
This pull request contains the following:
- create a new module: ``tgm.metrics``
- implement ``tgm.metrics.confusion_matrix``. The implementation is according to TNT: https://github.com/pytorch/tnt/blob/master/torchnet/meter/confusionmeter.py#L5
- going back to pytorch-cpu v1.0.1 for travis tests
- implement ``tgm.metrics.mean_iou``. The signature is compliant to ``tf.metrics.mean_iou``.